### PR TITLE
fix got undefined port when run dora without --port

### DIFF
--- a/bin/dora
+++ b/bin/dora
@@ -9,6 +9,6 @@ program
   .parse(process.argv);
 
 require('../lib')({
-  port: program.port,
+  port: program.port || '8000',
   plugins: program.plugins ? program.plugins.split(',') : [],
 });


### PR DESCRIPTION
run `dora` without `--port` will got:

<img width="198" alt="2015-12-08 11 13 12" src="https://cloud.githubusercontent.com/assets/663405/11646831/b95815ee-9d9c-11e5-9334-ad065bfdd403.png">
