### PR TITLE
fix resolve conflict

### DIFF
--- a/src/resolve.js
+++ b/src/resolve.js
@@ -17,7 +17,7 @@ export default function(id, resolveDir) {
 
   let result;
   resolveDir.some(dirname => {
-    result = tryResolve(id, dirname) || tryResolve(`dora-plugin-${id}`, dirname);
+    result = tryResolve(id, dirname);
     return result;
   });
   return result;

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -17,7 +17,7 @@ export default function(id, resolveDir) {
 
   let result;
   resolveDir.some(dirname => {
-    result = tryResolve(id, dirname);
+    result = tryResolve(`dora-plugin-${id}`, dirname) || tryResolve(id, dirname);
     return result;
   });
   return result;


### PR DESCRIPTION
按照原来的逻辑，如果依赖了 `some_module` 以及这个模块上的 `dora-plugin-some_module`，则会把 `some_module` 作为插件加载进来。

为了防止潜在的冲突，不提供自动前缀的方式。`--plugins` 参数就是提供完整的模块名称。
