### PR TITLE
调整 server.before 触发点以及添加 process.exit 方法

### DIFF
--- a/How-To-Write-A-Dora-Plugin.md
+++ b/How-To-Write-A-Dora-Plugin.md
@@ -42,4 +42,5 @@ Methods:
 - `middleware.after`
 - `server.before`
 - `server.after`
+- `process.exit`
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,6 @@ const defaultArgs = {
   resolveDir: [defaultCwd],
 };
 
-let notDestroy = true;
-
 export default function createServer(_args) {
   const args = assign({}, defaultArgs, _args);
   log.config(args);
@@ -55,19 +53,15 @@ export default function createServer(_args) {
     _applyPlugins('server.after');
   });
 
-
-  // exit 事件和 SIGINT 事件是否一定只会发生一次呢? 如果不是, 需要防止多次触发 process.exit
   process.on('exit', () => {
-    if (notDestroy) {
-      _applyPlugins('process.exit');
-    }
-    notDestroy = false;
+    _applyPlugins('process.exit');
   });
 
   process.on('SIGINT', () => {
-    if (notDestroy) {
-      _applyPlugins('process.exit');
-    }
-    notDestroy = false;
+    process.exit(0);
+  });
+
+  process.on('uncaughtException', () => {
+    process.exit(-1);
   });
 }


### PR DESCRIPTION
1. 将 server.before 方法的触发时间调整在 http.createServer 之后，并且将该 server 通过 `args.server` 传递给 plugin，使得 plugin 可以配置 server。这个改动点完全向前兼容。
2. 添加 process.exit 方法，在应用退出时，插件可以利用这个方法进行一些资源回收等操作，比如清空临时文件夹，释放文件占用或端口，等。
