### PR TITLE
支持 generator

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,11 @@
 {
   "extends": "eslint-config-airbnb/base",
+  "ecmaFeatures": {
+    "generators": true
+  },
+  "env": {
+    "es6": true
+  },
   "rules": {
     "no-console": [0],
     "space-before-function-paren": [2, "never"]

--- a/How-To-Write-A-Dora-Plugin.md
+++ b/How-To-Write-A-Dora-Plugin.md
@@ -35,6 +35,18 @@ export default {
 }
 ```
 
+use generator
+
+````js
+export default {
+  *'middleware.before'() {
+    yield new Promise(resolve, reject) {
+      setTimeout(resolve, 2000); // wait for 2 seconds
+    }
+  }
+}
+````
+
 Methods:
 
 - `middleware.before`

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "coveralls": "~2.11.4",
     "eslint": "~1.10.3",
     "eslint-config-airbnb": "~2.1.1",
-    "i": "^0.3.3",
     "jest-cli": "~0.8.1",
     "jest.automockoff": "~0.1.0",
     "pre-commit": "~1.1.2"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "lint"
   ],
   "dependencies": {
+    "babel-polyfill": "^6.3.14",
+    "co": "^4.6.0",
     "commander": "~2.9.0",
     "internal-ip": "~1.1.0",
     "is-plain-object": "~2.0.1",
@@ -35,14 +37,15 @@
   },
   "devDependencies": {
     "babel-cli": "~6.3.15",
-    "babel-core": "~6.3.15",
+    "babel-core": "~6.3.17",
     "babel-jest": "~6.0.1",
     "babel-plugin-add-module-exports": "~0.1.2",
     "babel-preset-es2015": "~6.3.13",
     "babel-preset-stage-0": "~6.3.13",
     "coveralls": "~2.11.4",
     "eslint": "~1.10.3",
-    "eslint-config-airbnb": "~2.1.0",
+    "eslint-config-airbnb": "~2.1.1",
+    "i": "^0.3.3",
     "jest-cli": "~0.8.1",
     "jest.automockoff": "~0.1.0",
     "pre-commit": "~1.1.2"

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
+import polyfill from 'babel-polyfill'; // eslint-disable-line
 import http from 'http';
 import koa from 'koa';
-import { resolvePlugins, applyPlugins, applyMiddlewares } from './plugin';
+import { resolvePlugins, applyPlugins, applyPluginsSync, applyMiddlewares } from './plugin';
 import assign from 'object-assign';
 import log from 'spm-log';
+import co from 'co';
 
 const defaultCwd = process.cwd();
 const defaultArgs = {
@@ -21,28 +23,40 @@ export default function createServer(_args) {
     cwd,
   };
   const plugins = resolvePlugins(pluginNames, args.resolveDir, args.cwd);
-  function _applyPlugins(name, applyArgs) {
-    return applyPlugins(plugins, name, pluginArgs, applyArgs);
+
+  function* _applyPlugins(name, applyArgs) {
+    return yield applyPlugins(plugins, name, pluginArgs, applyArgs);
   }
-  pluginArgs.applyPlugins = _applyPlugins;
+
+  function _applyPluginsSync(name, applyArgs) {
+    return applyPluginsSync(plugins, name, pluginArgs, applyArgs);
+  }
+
+  pluginArgs.applyPlugins = _applyPluginsSync;
+  pluginArgs.applyPluginsAsync = _applyPlugins;
+
   log.debug('dora', `[plugins] ${JSON.stringify(plugins)}`);
   const app = koa();
 
-  _applyPlugins('middleware.before');
-  applyMiddlewares(plugins, pluginArgs, app);
-  app.use(require('koa-static-with-post')(cwd));
-  app.use(require('koa-serve-index')(cwd, {
-    hidden: true,
-    view: 'details',
-  }));
-  _applyPlugins('middleware.after');
+  co(function* runApplyPlugins() {
+    yield _applyPlugins('middleware.before');
+    yield applyMiddlewares(plugins, pluginArgs, app);
+    app.use(require('koa-static-with-post')(cwd));
+    app.use(require('koa-serve-index')(cwd, {
+      hidden: true,
+      view: 'details',
+    }));
+    yield _applyPlugins('middleware.after');
 
-  const server = http.createServer(app.callback());
-  pluginArgs.server = server; // pass server to plugin
-  _applyPlugins('server.before');
+    const server = http.createServer(app.callback());
+    pluginArgs.server = server; // pass server to plugin
+    yield _applyPlugins('server.before');
 
-  server.listen(port, () => {
-    // Fix log, #8
+    yield new Promise((resolve, reject) => {
+      server.listen(port, resolve);
+      server.on('clientError', reject);
+    });
+
     const stream = process.stderr;
     if (stream.isTTY) {
       stream.cursorTo(0);
@@ -50,11 +64,15 @@ export default function createServer(_args) {
     }
 
     log.info('dora', `listened on ${port}`);
-    _applyPlugins('server.after');
+    yield _applyPlugins('server.after');
+  }).then(() => {
+    log.debug('dora', 'dora started.');
+  }, (err) => {
+    log.error('dora', err);
   });
 
   process.on('exit', () => {
-    _applyPlugins('process.exit');
+    _applyPluginsSync('process.exit');
   });
 
   process.on('SIGINT', () => {


### PR DESCRIPTION
1. 可以让插件有更强大的处理能力。
2. 可以让插件通过 generator 来阻塞 dora 的运行。比如可以让 proxy 插件的服务启动好后，再去启动 atool-build 的服务器。
3. 完全向前兼容，不使用 generator 的插件，仍然是原来的处理方式。
